### PR TITLE
Fix chat email batching and live preview sync

### DIFF
--- a/ai-chatbot-plugin/AI_CHATBOT_PLUGIN_ANALYSIS.md
+++ b/ai-chatbot-plugin/AI_CHATBOT_PLUGIN_ANALYSIS.md
@@ -93,3 +93,10 @@
 - Either include `assets/js/admin-settings.js` or remove the enqueue call.
 - Localize full frontend settings (provide `ai_chatbot_options.inactivity_timeout`) so JS runs without errors.
 - Wire spam filtering, add rate limiting, and improve error handling around OpenAI and cron retries.
+
+## 13. Изменения 2025-09-24
+- Добавлено подключение сгенерированного CSS-файла в `enqueue_scripts` и сохранение его URL при каждой регенерации, чтобы стили цветовых схем попадали на фронтенд.
+- Обработчик `ai_chatbot_save_realtime_settings` теперь санитизирует и сохраняет дополнительные поля (email, таймауты, тексты, ключи) и корректно обрабатывает значения чекбоксов.
+- `AI_ChatBot_Chat_History::send_chat_to_email()` использует адрес из настроек, форматирует тело с `\r\n` и отправляет через `wp_mail` на выбранного получателя.
+- Клиентский `chatbot.js` удаляет принудительную отправку истории, завершает сессию только после таймера неактивности через `ai_chatbot_session_end` и сбрасывает идентификатор.
+- `admin-realtime.js` собирает значения вручную, учитывает чекбоксы/радиокнопки, применяет предустановленные градиенты и приводит числовые параметры предпросмотра.

--- a/ai-chatbot-plugin/ai-chatbot.php
+++ b/ai-chatbot-plugin/ai-chatbot.php
@@ -78,6 +78,11 @@ class AIChatBot {
         if (get_option('ai_chatbot_enabled') == '1') {
             wp_enqueue_script('ai-chatbot-js', AI_CHATBOT_PLUGIN_URL . 'assets/js/chatbot.js', array('jquery'), '1.0.0', true);
             wp_enqueue_style('ai-chatbot-css', AI_CHATBOT_PLUGIN_URL . 'assets/css/chatbot.css', array(), '1.0.0');
+
+            $generated_css = get_option('ai_chatbot_generated_css');
+            if ($generated_css) {
+                wp_enqueue_style('ai-chatbot-generated-css', $generated_css, array('ai-chatbot-css'), null);
+            }
             
             wp_localize_script('ai-chatbot-js', 'ai_chatbot_ajax', array(
                 'ajax_url' => admin_url('admin-ajax.php'),
@@ -246,8 +251,20 @@ class AIChatBot {
         // Подключаем скрипты для админки
         if (isset($_GET['page']) && $_GET['page'] === 'ai-chatbot-settings') {
             wp_enqueue_style('ai-chatbot-admin', AI_CHATBOT_PLUGIN_URL . 'assets/css/admin.css');
-            wp_enqueue_script('ai-chatbot-admin', AI_CHATBOT_PLUGIN_URL . 'assets/js/admin-settings.js', array('jquery'), '1.0.0', true);
-            wp_enqueue_script('ai-chatbot-admin-realtime', AI_CHATBOT_PLUGIN_URL . 'assets/js/admin-realtime.js', array('jquery'), '1.0.0', true);
+            wp_enqueue_script(
+                'ai-chatbot-admin',
+                AI_CHATBOT_PLUGIN_URL . 'assets/js/admin-settings.js',
+                array('jquery'),
+                '1.0.0',
+                true
+            );
+            wp_enqueue_script(
+                'ai-chatbot-admin-realtime',
+                AI_CHATBOT_PLUGIN_URL . 'assets/js/admin-realtime.js',
+                array('jquery'),
+                '1.0.0',
+                true
+            );
             wp_localize_script('ai-chatbot-admin', 'ai_chatbot_admin', array(
                 'nonce' => wp_create_nonce('ai_chatbot_nonce')
             ));
@@ -271,32 +288,73 @@ class AIChatBot {
         // Сохраняем все настройки
         foreach ($settings as $key => $value) {
             $option_name = 'ai_chatbot_' . $key;
-            
+
             switch ($key) {
                 case 'bot_name_color':
                 case 'primary_color':
                 case 'secondary_color':
                     update_option($option_name, sanitize_hex_color($value));
                     break;
-                    
+
                 case 'margin':
                 case 'widget_size':
                 case 'avatar_size':
                 case 'font_size':
                     update_option($option_name, intval($value));
                     break;
-                    
+
+                case 'inactivity_timeout':
+                    $timeout = max(60000, intval($value));
+                    update_option($option_name, $timeout);
+                    break;
+
                 case 'color_scheme':
                 case 'window_size':
                 case 'font_family':
                 case 'animation':
+                case 'language':
+                case 'openai_model':
                     update_option($option_name, sanitize_text_field($value));
                     break;
-                    
+
+                case 'bot_name':
+                    update_option($option_name, sanitize_text_field($value));
+                    break;
+
+                case 'welcome_message':
+                case 'system_prompt':
+                    update_option($option_name, sanitize_textarea_field($value));
+                    break;
+
+                case 'avatar_url':
+                    update_option($option_name, esc_url_raw($value));
+                    break;
+
+                case 'email_to':
+                    update_option($option_name, sanitize_email($value));
+                    break;
+
+                case 'openai_key':
+                    update_option($option_name, sanitize_text_field($value));
+                    break;
+
+                case 'enabled':
+                    update_option($option_name, $value === '1' ? '1' : '0');
+                    break;
+
                 case 'custom_text':
                     if (is_array($value)) {
                         $sanitized_text = array_map('sanitize_text_field', $value);
                         update_option($option_name, $sanitized_text);
+                    }
+                    break;
+
+                default:
+                    if (is_array($value)) {
+                        $sanitized = array_map('sanitize_text_field', $value);
+                        update_option($option_name, $sanitized);
+                    } else {
+                        update_option($option_name, sanitize_text_field($value));
                     }
                     break;
             }
@@ -304,7 +362,7 @@ class AIChatBot {
         
         // Генерируем новый CSS
         if (!class_exists('AI_ChatBot_CSS_Generator')) {
-            require_once AI_CHATBOT_PLUGIN_DIR . 'includes/class-css-generator.php';
+            require_once AI_CHATBOT_PLUGIN_PATH . 'includes/class-css-generator.php';
         }
         
         $css_generator = new AI_ChatBot_CSS_Generator();

--- a/ai-chatbot-plugin/assets/js/admin-realtime.js
+++ b/ai-chatbot-plugin/assets/js/admin-realtime.js
@@ -1,30 +1,90 @@
 jQuery(document).ready(function($) {
-    // Обработчик всех изменений в форме настроек
-    $('.ai-chatbot-settings-form input, .ai-chatbot-settings-form select').on('change input', function() {
-        var $input = $(this);
-        var setting = $input.attr('name').replace('ai_chatbot_', '');
-        var value = $input.val();
-        
-        // Собираем все текущие настройки
+    var $form = $('.ai-chatbot-settings-form');
+
+    if (!$form.length) {
+        return;
+    }
+
+    function assignSetting(target, key, value) {
+        if (key.indexOf('[') === -1) {
+            target[key] = value;
+            return;
+        }
+
+        var parts = key.replace(/\]/g, '').split('[');
+        var cursor = target;
+
+        for (var i = 0; i < parts.length; i++) {
+            var part = parts[i];
+            if (i === parts.length - 1) {
+                cursor[part] = value;
+            } else {
+                if (typeof cursor[part] !== 'object' || cursor[part] === null) {
+                    cursor[part] = {};
+                }
+                cursor = cursor[part];
+            }
+        }
+    }
+
+    function collectSettings() {
         var settings = {};
-        $('.ai-chatbot-settings-form').serializeArray().forEach(function(item) {
-            settings[item.name.replace('ai_chatbot_', '')] = item.value;
+
+        $form.find('input, select, textarea').each(function() {
+            var $field = $(this);
+
+            if ($field.is(':disabled')) {
+                return;
+            }
+
+            var name = $field.attr('name');
+            if (!name || name.indexOf('ai_chatbot_') !== 0) {
+                return;
+            }
+
+            var key = name.replace('ai_chatbot_', '');
+            var value;
+
+            if ($field.is(':checkbox')) {
+                value = $field.is(':checked') ? ($field.val() ? $field.val() : '1') : '0';
+            } else if ($field.is(':radio')) {
+                if (!$field.is(':checked')) {
+                    return;
+                }
+                value = $field.val();
+            } else {
+                value = $field.val();
+            }
+
+            assignSetting(settings, key, value);
         });
-        
-        // Применяем изменения сразу к виджету и предпросмотру
+
+        return settings;
+    }
+
+    function handleRealtimeChange() {
+        var settings = collectSettings();
         applySettingsToWidget(settings);
-        
-        // Сохраняем настройки через AJAX
         saveSettings(settings);
-    });
+    }
+
+    $form.on('change input', 'input, select, textarea', handleRealtimeChange);
+
+    applySettingsToWidget(collectSettings());
 
     function applySettingsToWidget(settings) {
-        // Применяем к предпросмотру и живому виджету
         var $targets = $('.ai-chatbot-preview, .ai-chatbot-container');
-        
+
+        var gradients = {
+            'default': ['#667eea', '#764ba2'],
+            'blue': ['#2563eb', '#1d4ed8'],
+            'green': ['#059669', '#047857'],
+            'purple': ['#7c3aed', '#5b21b6']
+        };
+
         $targets.each(function() {
             var $container = $(this);
-            
+
             // Применяем отступы
             if (settings.margin) {
                 $container.css({
@@ -35,13 +95,22 @@ jQuery(document).ready(function($) {
             
             // Применяем цвета
             var gradient = '';
+
             if (settings.color_scheme === 'custom') {
-                gradient = `linear-gradient(135deg, ${settings.primary_color} 0%, ${settings.secondary_color} 100%)`;
+                if (settings.primary_color && settings.secondary_color) {
+                    gradient = `linear-gradient(135deg, ${settings.primary_color} 0%, ${settings.secondary_color} 100%)`;
+                }
+            } else if (settings.color_scheme && gradients[settings.color_scheme]) {
+                var preset = gradients[settings.color_scheme];
+                gradient = `linear-gradient(135deg, ${preset[0]} 0%, ${preset[1]} 100%)`;
             }
-            
+
+            var gradientTargets = $container.find('.ai-chatbot-toggle, .ai-chatbot-header, .ai-chatbot-send, .ai-chatbot-message.user .ai-chatbot-message-content');
+
             if (gradient) {
-                $container.find('.ai-chatbot-toggle, .ai-chatbot-header, .ai-chatbot-send, .ai-chatbot-message.user .ai-chatbot-message-content')
-                    .css('background', gradient);
+                gradientTargets.css('background', gradient);
+            } else {
+                gradientTargets.css('background', '');
             }
             
             // Цвет имени бота
@@ -51,10 +120,13 @@ jQuery(document).ready(function($) {
             
             // Размер виджета
             if (settings.widget_size) {
-                $container.find('.ai-chatbot-toggle').css({
-                    'width': settings.widget_size + 'px',
-                    'height': settings.widget_size + 'px'
-                });
+                var size = parseInt(settings.widget_size, 10);
+                if (!isNaN(size)) {
+                    $container.find('.ai-chatbot-toggle').css({
+                        'width': size + 'px',
+                        'height': size + 'px'
+                    });
+                }
             }
             
             // Размер окна
@@ -71,12 +143,15 @@ jQuery(document).ready(function($) {
             
             // Размер аватара
             if (settings.avatar_size) {
-                $container.find('.ai-chatbot-avatar').css({
-                    'width': settings.avatar_size + 'px',
-                    'height': settings.avatar_size + 'px'
-                });
+                var avatarSize = parseInt(settings.avatar_size, 10);
+                if (!isNaN(avatarSize)) {
+                    $container.find('.ai-chatbot-avatar').css({
+                        'width': avatarSize + 'px',
+                        'height': avatarSize + 'px'
+                    });
+                }
             }
-            
+
             // Шрифт
             if (settings.font_family && settings.font_size) {
                 const fonts = {
@@ -86,9 +161,11 @@ jQuery(document).ready(function($) {
                     'lato': 'Lato, sans-serif'
                 };
                 
+                var fontSize = parseInt(settings.font_size, 10);
+
                 $container.css({
                     'font-family': fonts[settings.font_family] || fonts['system-default'],
-                    'font-size': settings.font_size + 'px'
+                    'font-size': (isNaN(fontSize) ? settings.font_size : fontSize) + 'px'
                 });
             }
         });

--- a/ai-chatbot-plugin/assets/js/admin-settings.js
+++ b/ai-chatbot-plugin/assets/js/admin-settings.js
@@ -1,0 +1,29 @@
+(function($) {
+    'use strict';
+
+    $(function() {
+        var $settingsForm = $('form').filter(function() {
+            return $(this).find('#ai_chatbot_enabled').length > 0;
+        }).first();
+
+        if ($settingsForm.length && !$settingsForm.hasClass('ai-chatbot-settings-form')) {
+            $settingsForm.addClass('ai-chatbot-settings-form');
+        }
+
+        var $colorScheme = $('#ai_chatbot_color_scheme');
+        var $customColors = $('#custom-colors');
+
+        function toggleCustomColors() {
+            if ($customColors.length === 0) {
+                return;
+            }
+
+            $customColors.toggle($colorScheme.val() === 'custom');
+        }
+
+        if ($colorScheme.length) {
+            toggleCustomColors();
+            $colorScheme.on('change', toggleCustomColors);
+        }
+    });
+})(jQuery);

--- a/ai-chatbot-plugin/assets/js/chatbot.js
+++ b/ai-chatbot-plugin/assets/js/chatbot.js
@@ -6,9 +6,77 @@ jQuery(document).ready(function($) {
     let historyAlreadySent = false;
     let pendingHistorySend = false;
     const INACTIVITY_TIMEOUT = ai_chatbot_options.inactivity_timeout; // Время неактивности из настроек админ-панели
-    
+    const SESSION_ID_KEY = 'ai_chatbot_session_id';
+    let cachedSessionId = null;
+
+    function safeStorage(name) {
+        try {
+            return window[name];
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function readSessionId(storage) {
+        if (!storage) {
+            return null;
+        }
+
+        try {
+            return storage.getItem(SESSION_ID_KEY);
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function writeSessionId(storage, id) {
+        if (!storage) {
+            return false;
+        }
+
+        try {
+            storage.setItem(SESSION_ID_KEY, id);
+            return true;
+        } catch (e) {
+            return false;
+        }
+    }
+
+    function generateSessionId() {
+        return 'chatbot_' + Date.now().toString(36) + '_' + Math.random().toString(36).substring(2, 11);
+    }
+
+    function getSessionId() {
+        if (cachedSessionId) {
+            return cachedSessionId;
+        }
+
+        const storages = [safeStorage('localStorage'), safeStorage('sessionStorage')];
+
+        for (let i = 0; i < storages.length; i++) {
+            const stored = readSessionId(storages[i]);
+            if (stored) {
+                cachedSessionId = stored;
+                break;
+            }
+        }
+
+        if (!cachedSessionId) {
+            cachedSessionId = generateSessionId();
+            for (let i = 0; i < storages.length; i++) {
+                if (writeSessionId(storages[i], cachedSessionId)) {
+                    break;
+                }
+            }
+        }
+
+        return cachedSessionId;
+    }
+
     // Инициализация чата
     function initChatBot() {
+        getSessionId();
+
         const $container = $('.ai-chatbot-container');
         const $toggle = $('.ai-chatbot-toggle');
         const $window = $('.ai-chatbot-window');
@@ -125,7 +193,12 @@ jQuery(document).ready(function($) {
         // Отправляем историю при закрытии чата если есть сообщения
         const messages = getAllMessages();
         if (messages.length > 0 && !historyAlreadySent) {
-            sendChatHistoryImmediately();
+            if (inactivityTimer) {
+                clearTimeout(inactivityTimer);
+            }
+            inactivityTimer = setTimeout(() => {
+                sendChatHistory();
+            }, INACTIVITY_TIMEOUT);
         }
     }
     
@@ -156,7 +229,8 @@ jQuery(document).ready(function($) {
             data: {
                 action: 'ai_chatbot_message',
                 message: message,
-                nonce: ai_chatbot_ajax.nonce
+                nonce: ai_chatbot_ajax.nonce,
+                session_id: getSessionId()
             },
             success: handleBotResponse,
             error: function() {
@@ -305,16 +379,36 @@ jQuery(document).ready(function($) {
                     console.warn('localStorage недоступен, пробуем sessionStorage');
                     sessionStorage.setItem('ai_chatbot_messages', JSON.stringify(messages));
                     sessionStorage.setItem('ai_chatbot_last_visit', Date.now());
+                    try {
+                        sessionStorage.setItem(SESSION_ID_KEY, getSessionId());
+                    } catch (storageError) {
+                        // Игнорируем невозможность сохранить идентификатор сессии
+                    }
                     return;
                 }
-                
+
                 // Если localStorage доступен, используем его
                 localStorage.setItem('ai_chatbot_messages', JSON.stringify(messages));
                 localStorage.setItem('ai_chatbot_last_visit', Date.now());
-                
+
                 // Дублируем в sessionStorage для надежности
                 sessionStorage.setItem('ai_chatbot_messages', JSON.stringify(messages));
                 sessionStorage.setItem('ai_chatbot_last_visit', Date.now());
+
+                const sessionId = getSessionId();
+                if (sessionId) {
+                    try {
+                        localStorage.setItem(SESSION_ID_KEY, sessionId);
+                    } catch (storageError) {
+                        // Игнорируем невозможность сохранить идентификатор сессии
+                    }
+
+                    try {
+                        sessionStorage.setItem(SESSION_ID_KEY, sessionId);
+                    } catch (storageError) {
+                        // Игнорируем невозможность сохранить идентификатор сессии
+                    }
+                }
             }
         } catch (e) {
             console.error('Ошибка при сохранении истории:', e);
@@ -382,16 +476,20 @@ jQuery(document).ready(function($) {
         try {
             localStorage.removeItem('ai_chatbot_messages');
             localStorage.removeItem('ai_chatbot_last_visit');
+            localStorage.removeItem(SESSION_ID_KEY);
         } catch (e) {
             console.warn('Ошибка при очистке localStorage:', e);
         }
-        
+
         try {
             sessionStorage.removeItem('ai_chatbot_messages');
             sessionStorage.removeItem('ai_chatbot_last_visit');
+            sessionStorage.removeItem(SESSION_ID_KEY);
         } catch (e) {
             console.warn('Ошибка при очистке sessionStorage:', e);
         }
+
+        cachedSessionId = null;
     }
     
     // Получить все сообщения чата
@@ -417,82 +515,36 @@ jQuery(document).ready(function($) {
             return;
         }
         
-        const chatHistory = getAllMessages();
-        if (chatHistory.length === 0) {
+        const messages = getAllMessages();
+        if (messages.length === 0) {
             return;
         }
         
         pendingHistorySend = true;
-        
-        // Отправляем историю на email и в Telegram
+
         $.ajax({
             url: ai_chatbot_ajax.ajax_url,
             type: 'POST',
             data: {
-                action: 'ai_chatbot_send_email',
-                history: JSON.stringify(chatHistory),
-                nonce: ai_chatbot_ajax.nonce
+                action: 'ai_chatbot_session_end',
+                nonce: ai_chatbot_ajax.nonce,
+                session_id: getSessionId()
             },
             success: function(response) {
                 if (response.success) {
                     historyAlreadySent = true;
-                    saveState(); // Сохраняем флаг
-                    console.log('История чата успешно отправлена');
+                    clearStorage();
+                    console.log('Сессия чата завершена по таймеру неактивности');
                 } else {
-                    console.error('AI ChatBot: Failed to send chat history -', response.data);
+                    console.error('AI ChatBot: не удалось завершить сессию -', response.data);
                 }
                 pendingHistorySend = false;
             },
             error: function(xhr, status, error) {
-                console.error('AI ChatBot: Error sending chat history -', error);
+                console.error('AI ChatBot: ошибка завершения сессии -', error);
                 pendingHistorySend = false;
             }
         });
-    }
-    
-    // Функция для немедленной отправки истории (при закрытии чата/страницы)
-    function sendChatHistoryImmediately() {
-        if (historyAlreadySent || pendingHistorySend) {
-            return;
-        }
-        
-        const chatHistory = getAllMessages();
-        if (chatHistory.length === 0) {
-            return;
-        }
-        
-        pendingHistorySend = true;
-        historyAlreadySent = true;
-        saveState(); // Сохраняем флаг немедленно
-        
-        // Используем navigator.sendBeacon для надежной отправки при закрытии
-        if (navigator.sendBeacon) {
-            const formData = new FormData();
-            formData.append('action', 'ai_chatbot_send_email');
-            formData.append('history', JSON.stringify(chatHistory));
-            formData.append('nonce', ai_chatbot_ajax.nonce);
-            
-            navigator.sendBeacon(ai_chatbot_ajax.ajax_url, formData);
-            console.log('История отправлена через sendBeacon');
-        } else {
-            // Fallback для старых браузеров
-            $.ajax({
-                url: ai_chatbot_ajax.ajax_url,
-                type: 'POST',
-                async: false, // Синхронный запрос при закрытии
-                data: {
-                    action: 'ai_chatbot_send_email',
-                    history: JSON.stringify(chatHistory),
-                    nonce: ai_chatbot_ajax.nonce
-                },
-                success: function(response) {
-                    console.log('История чата отправлена при закрытии');
-                },
-                error: function(xhr, status, error) {
-                    console.error('Ошибка отправки истории при закрытии:', error);
-                }
-            });
-        }
     }
     
     // Обработка ошибок
@@ -662,30 +714,16 @@ jQuery(document).ready(function($) {
     setInterval(saveState, 30000);
     
     // Сохранение состояния перед закрытием страницы
-    $(window).on('beforeunload', function(e) {
-        // Отправляем историю немедленно при закрытии страницы
-        const messages = getAllMessages();
-        if (messages.length > 0 && !historyAlreadySent) {
-            sendChatHistoryImmediately();
-        }
+    $(window).on('beforeunload', function() {
         saveState();
     });
-    
-    // Дополнительные обработчики для отправки истории
+
     $(window).on('unload pagehide', function() {
-        const messages = getAllMessages();
-        if (messages.length > 0 && !historyAlreadySent) {
-            sendChatHistoryImmediately();
-        }
+        saveState();
     });
-    
-    // Обработчик для мобильных устройств
+
     document.addEventListener('visibilitychange', function() {
         if (document.visibilityState === 'hidden') {
-            const messages = getAllMessages();
-            if (messages.length > 0 && !historyAlreadySent) {
-                sendChatHistoryImmediately();
-            }
             saveState();
         }
     });

--- a/ai-chatbot-plugin/includes/class-chat-history.php
+++ b/ai-chatbot-plugin/includes/class-chat-history.php
@@ -164,22 +164,43 @@ class AI_ChatBot_Chat_History {
             return false;
         }
         
-        $admin_email = get_option('admin_email');
-        $subject = sprintf('Р§Р°С‚ СЃ РїРѕР»СЊР·РѕРІР°С‚РµР»РµРј (ID: %s)', $session_id);
-        
-        // Р¤РѕСЂРјР°С‚РёСЂСѓРµРј СЃРѕРѕР±С‰РµРЅРёСЏ РІ С‡РёС‚Р°РµРјС‹Р№ РІРёРґ
-        $body = "РСЃС‚РѕСЂРёСЏ РїРµСЂРµРїРёСЃРєРё:\n\n";
-        foreach ($messages as $message) {
-            $time = date('d.m.Y H:i:s', $message['timestamp']);
-            $sender = $message['sender'] === 'user' ? 'РџРѕР»СЊР·РѕРІР°С‚РµР»СЊ' : 'Р‘РѕС‚';
-            $body .= "[$time] $sender:\n{$message['text']}\n\n";
+        $recipient = get_option('ai_chatbot_email_to');
+        if (!$recipient || !is_email($recipient)) {
+            $recipient = get_option('admin_email');
         }
         
-        // РћС‚РїСЂР°РІР»СЏРµРј email
-        $headers = array('Content-Type: text/plain; charset=UTF-8');
-        $result = wp_mail($admin_email, $subject, $body, $headers);
+        if (!$recipient || !is_email($recipient)) {
+            return false;
+        }
         
-        return $result;
+        $subject = sprintf('Чат с пользователем (ID: %s)', $session_id);
+        $site_name = wp_specialchars_decode(get_bloginfo('name'), ENT_QUOTES);
+        
+        $lines = array();
+        if (!empty($site_name)) {
+            $lines[] = 'Сайт: ' . $site_name;
+        }
+        $lines[] = 'История переписки:';
+        $lines[] = '';
+        
+        foreach ($messages as $message) {
+            $timestamp = isset($message['timestamp']) ? intval($message['timestamp']) : time();
+            $time = date_i18n('d.m.Y H:i:s', $timestamp);
+            $sender = isset($message['sender']) && $message['sender'] === 'user' ? 'Пользователь' : 'Бот';
+            $text = isset($message['text']) ? wp_strip_all_tags($message['text']) : '';
+            $text = preg_replace("/\r?\n/", "\r\n", $text);
+        
+            $lines[] = sprintf('[%s] %s:', $time, $sender);
+            if ($text !== '') {
+                $lines[] = $text;
+            }
+            $lines[] = '';
+        }
+        
+        $body = implode("\r\n", $lines);
+        $headers = array('Content-Type: text/plain; charset=UTF-8');
+        
+        return wp_mail($recipient, $subject, $body, $headers);
     }
     
     private function get_chat_file_path($session_id) {

--- a/ai-chatbot-plugin/includes/class-css-generator.php
+++ b/ai-chatbot-plugin/includes/class-css-generator.php
@@ -133,7 +133,10 @@ class AI_ChatBot_CSS_Generator {
         // Обновляем версию стилей для принудительного обновления
         $style_version = time();
         update_option('ai_chatbot_style_version', $style_version);
-        
-        return wp_upload_dir()['baseurl'] . "/ai-chatbot/ai-chatbot-{$timestamp}.css?v={$style_version}";
+
+        $css_url = $upload_dir['baseurl'] . "/ai-chatbot/ai-chatbot-{$timestamp}.css?v={$style_version}";
+        update_option('ai_chatbot_generated_css', $css_url);
+
+        return $css_url;
     }
 }


### PR DESCRIPTION
## Summary
- enqueue generated chatbot stylesheets and persist their URLs when regenerating
- expand realtime settings persistence to sanitize additional fields and update admin preview handling
- rely on session end to deliver chat history with proper email formatting and remove aggressive frontend flushes

## Testing
- php -l ai-chatbot-plugin/ai-chatbot.php
- php -l ai-chatbot-plugin/includes/class-css-generator.php
- php -l ai-chatbot-plugin/includes/class-chat-history.php

------
https://chatgpt.com/codex/tasks/task_e_68d3b7565500832b843c470d9f1ad7ef